### PR TITLE
Testing Red Ball Demo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,9 @@ add_subdirectory(src/cartesian-control)
 # Build gaze controller tests
 add_subdirectory(src/gaze-control)
 
+# Build demoRedBall test
+add_subdirectory(src/demoRedBall)
+
 if(ICUB_TESTS_USES_CODYCO)
     add_subdirectory(src/torqueControl-gravityConsistency)
 endif()

--- a/src/demoRedBall/CMakeLists.txt
+++ b/src/demoRedBall/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Copyright: (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
+# Authors: Ugo Pattacini <ugo.pattacini@iit.it>
+# CopyPolicy: Released under the terms of the GNU GPL v2.0.
+
+cmake_minimum_required(VERSION 2.8.9)
+
+# set the project name
+project(DemoRedBallTest)
+
+# add the required cmake packages
+find_package(RTF)
+find_package(RTF COMPONENTS DLL)
+find_package(YARP REQUIRED)
+
+list(APPEND CMAKE_MODULE_PATH ${YARP_MODULE_PATH})
+
+# add include directories
+include_directories(${CMAKE_SOURCE_DIR}
+                    ${RTF_INCLUDE_DIRS}
+                    ${YARP_INCLUDE_DIRS}
+                    ${YARP_HELPERS_INCLUDE_DIR})
+
+# add required libraries
+link_libraries(${RTF_LIBRARIES} ${YARP_LIBRARIES})
+
+# import math symbols from standard cmath
+add_definitions(-D_USE_MATH_DEFINES)
+
+# add the source codes to build the plugin library
+add_library(${PROJECT_NAME} MODULE ${PROJECT_NAME}.h ${PROJECT_NAME}.cpp)
+
+# set the installation options
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}
+        COMPONENT runtime
+        LIBRARY DESTINATION lib)
+

--- a/src/demoRedBall/DemoRedBallTest.cpp
+++ b/src/demoRedBall/DemoRedBallTest.cpp
@@ -1,0 +1,204 @@
+/* 
+ * Copyright (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
+ * Author: Ugo Pattacini
+ * email:  ugo.pattacini@iit.it
+ * Permission is granted to copy, distribute, and/or modify this program
+ * under the terms of the GNU General Public License, version 2 or any
+ * later version published by the Free Software Foundation.
+ *
+ * A copy of the license can be found at
+ * http://www.robotcub.org/icub/license/gpl.txt
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details
+*/
+
+#include <string>
+#include <rtf/dll/Plugin.h>
+#include <yarp/os/Time.h>
+#include <yarp/os/BufferedPort.h>
+#include <yarp/os/Bottle.h>
+#include <yarp/dev/CartesianControl.h>
+#include <yarp/dev/GazeControl.h>
+#include <yarp/sig/Vector.h>
+#include <yarp/sig/Matrix.h>
+#include <yarp/math/Math.h>
+
+#include "DemoRedBallTest.h"
+
+using namespace std;
+using namespace RTF;
+using namespace yarp::os;
+using namespace yarp::dev;
+using namespace yarp::sig;
+using namespace yarp::math;
+
+// prepare the plugin
+PREPARE_PLUGIN(DemoRedBallTest)
+
+
+/***********************************************************************************/ 
+class DemoRedBallPosition : public RateThread
+{
+    string name;    
+    IGazeControl *igaze;
+    string eye;
+    Vector pos;
+    BufferedPort<Bottle> port;
+
+    bool threadInit()
+    {
+        port.open(("/"+name+"/redballpos:o"));
+    }
+
+    void run()
+    {
+        if (igaze!=NULL)
+        {
+            Vector x,o;
+            if (eye=="left")
+                gazeCtrl->getLeftEyePose(x,o);
+            else
+                gazeCtrl->getRightEyePose(x,o);
+
+            Matrix T=axis2dcm(o);
+            T.setSubcol(x,0,3);
+            Vector pos_=T*pos;
+
+            Bottle &cmd=port.prepare();
+            cmd.clear();
+            cmd.addDouble(pos_[0]);
+            cmd.addDouble(pos_[1]);
+            cmd.addDouble(pos_[2]);
+            cmd.addDouble(0.0);
+            cmd.addDouble(0.0);
+            cmd.addDouble(0.0);
+            cmd.addDouble(1.0);
+            port.write();
+        }
+    }
+
+    void threadRelease()
+    {
+        port.close();
+    }
+
+public:
+    DemoRedBallPosition(const string &name_,
+                        IGazeControl *igaze_,
+                        const string &eye_) :
+                        RateThread(100), name(name_),
+                        igaze(igaze_), eye(eye_),
+                        pos(4,0.0)
+    {
+        pos[3]=1.0;
+    }
+
+    bool setPos(const Vector &pos)
+    {
+        if (pos.length()>=3)
+        {
+            this->pos.setSubvector(0,pos.subVector(0,2));
+            return true;
+        }
+        else
+            return false;
+    }
+};
+
+
+/***********************************************************************************/
+DemoRedBallTest::DemoRedBallTest() : YarpTestCase("DemoRedBallTest"), redBallPos(NULL)
+{
+}
+
+
+/***********************************************************************************/
+DemoRedBallTest::~DemoRedBallTest()
+{
+    delete redBallPos;
+}
+
+
+/***********************************************************************************/
+bool DemoRedBallTest::setup(Property &property)
+{
+    string context=property.check("context",Value("demoRedBall")).asString();
+    string from=property.check("from",Value("config.ini")).asString();
+
+    Property option;
+    option.put("device","cartesiancontrollerclient");
+    option.put("remote",("/"+robot+"/"+"cartesianController/"+arm+"_arm"));
+    option.put("local",("/"+getName()+"/"+arm+"_arm"));
+
+    RTF_TEST_REPORT(Asserter::format("Opening Cartesian Controller Client for %s_arm",arm.c_str()));
+    RTF_ASSERT_ERROR_IF(driver.open(option),"Unable to open the client!");
+    return true;
+}
+
+
+/***********************************************************************************/
+void DemoRedBallTest::tearDown()
+{
+    RTF_TEST_REPORT("Closing Cartesian Controller Client");
+    RTF_ASSERT_FAIL_IF(driver.close(),"Unable to close the client!");
+}
+
+
+/***********************************************************************************/
+void DemoRedBallTest::run()
+{
+    ICartesianControl *iarm;
+    RTF_TEST_CHECK(driver.view(iarm),"Opening the view on the device!");
+
+    bool done;
+
+    Vector x,o;    
+    double t0=Time::now();
+    while (Time::now()-t0<5.0)
+    {
+        done=iarm->getPose(x,o);
+        if (done)
+            break;
+        Time::delay(0.1);
+    }
+    RTF_TEST_CHECK(done,"Initial pose retrieved!");
+
+    RTF_TEST_REPORT("Setting up the context");
+    int context;
+    iarm->storeContext(&context);
+
+    Vector dof;
+    iarm->getDOF(dof); dof=1.0;
+    iarm->setDOF(dof,dof);
+    iarm->setTrajTime(1.0);
+
+    RTF_TEST_REPORT("Reaching for the target");
+    Vector xd(3,0.0); xd[0]=-0.4;
+    iarm->goToPositionSync(xd);
+
+    RTF_TEST_REPORT("Waiting");
+    iarm->waitMotionDone(1.0,5.0);
+
+    iarm->checkMotionDone(&done);
+    RTF_TEST_CHECK(done,"Target reached!");
+
+    RTF_TEST_REPORT("Going back to starting pose");
+    iarm->setLimits(0,0.0,0.0);
+    iarm->setLimits(1,0.0,0.0);
+    iarm->setLimits(2,0.0,0.0);
+    iarm->goToPoseSync(x,o);
+
+    RTF_TEST_REPORT("Waiting");
+    iarm->waitMotionDone(1.0,5.0);
+
+    iarm->checkMotionDone(&done);
+    RTF_TEST_CHECK(done,"Starting pose reached!");
+
+    RTF_TEST_REPORT("Cleaning up the context");
+    iarm->restoreContext(context);
+    iarm->deleteContext(context);
+}
+

--- a/src/demoRedBall/DemoRedBallTest.cpp
+++ b/src/demoRedBall/DemoRedBallTest.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <rtf/dll/Plugin.h>
 #include <yarp/os/Time.h>
+#include <yarp/os/Network.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/ResourceFinder.h>
@@ -49,7 +50,11 @@ class DemoRedBallPosition : public RateThread
 
     bool threadInit()
     {
-        return port.open(("/"+name+"/redballpos:o"));
+        string dest="/demoRedBall/trackTarget:i";
+        port.open(("/"+name+"/redballpos:o"));
+        RTF_ASSERT_ERROR_IF(Network::connect(port.getName(),dest,"udp"),
+                            Asserter::format("Unable to connect to %s!",dest.c_str()));
+        return true;
     }
 
     void run()

--- a/src/demoRedBall/DemoRedBallTest.h
+++ b/src/demoRedBall/DemoRedBallTest.h
@@ -18,10 +18,14 @@
 #ifndef _DEMOREDBALL_H_
 #define _DEMOREDBALL_H_
 
+#include <string>
 #include <rtf/yarp/YarpTestCase.h>
 #include <yarp/os/Property.h>
 #include <yarp/os/RateThread.h>
 #include <yarp/dev/PolyDriver.h>
+#include <yarp/dev/IEncoders.h>
+#include <yarp/dev/CartesianControl.h>
+#include <yarp/sig/Vector.h>
 
 /**
 * \ingroup icub-tests
@@ -36,6 +40,15 @@
 */
 class DemoRedBallTest : public YarpTestCase
 {
+    struct {
+        std::string robot;
+        std::string eye;
+        double reach_tol;
+        bool use_left;
+        bool use_right;
+        yarp::sig::Vector home_arm;
+    } params;
+
     yarp::dev::PolyDriver drvJointArmL;
     yarp::dev::PolyDriver drvJointArmR;
     yarp::dev::PolyDriver drvJointTorso;
@@ -44,7 +57,13 @@ class DemoRedBallTest : public YarpTestCase
     yarp::dev::PolyDriver drvCartArmR;
     yarp::dev::PolyDriver drvGaze;
 
+    struct {
+    yarp::dev::ICartesianControl *iarm;
+    yarp::dev::IEncoders         *ienc;
+    } arm_under_test;
+
     yarp::os::RateThread *redBallPos;
+    void testBallPosition(const yarp::sig::Vector &pos);
 
 public:
     DemoRedBallTest();

--- a/src/demoRedBall/DemoRedBallTest.h
+++ b/src/demoRedBall/DemoRedBallTest.h
@@ -33,10 +33,10 @@
 * This test verifies the point-to-point cartesian movement.
 *
 * Accepts the following parameters:
-* | Parameter name | Type   | Units | Default Value | Required |  Description  | Notes |
-* |:--------------:|:------:|:-----:|:-------------:|:--------:|:-------------:|:-----:|
-* |     context    | string |   -   |  demoRedBall  |    No    |   context containing the demoRedBall conf file  |   -   |
-* |      from      | string |   -   |  config.ini   |    No    |   demoRedBall configuration file  |   -   |
+* | Parameter name | Type   | Units |  Default Value   | Required |  Description  | Notes |
+* |:--------------:|:------:|:-----:|:----------------:|:--------:|:-------------:|:-----:|
+* |     context    | string |   -   |  demoRedBall     |    No    |   context containing the demoRedBall conf file  |   -   |
+* |      from      | string |   -   |  config-test.ini |    No    |   demoRedBall configuration file  |   -   |
 */
 class DemoRedBallTest : public YarpTestCase
 {

--- a/src/demoRedBall/DemoRedBallTest.h
+++ b/src/demoRedBall/DemoRedBallTest.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
+ * Author: Ugo Pattacini
+ * email:  ugo.pattacini@iit.it
+ * Permission is granted to copy, distribute, and/or modify this program
+ * under the terms of the GNU General Public License, version 2 or any
+ * later version published by the Free Software Foundation.
+ *
+ * A copy of the license can be found at
+ * http://www.robotcub.org/icub/license/gpl.txt
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details
+*/
+
+#ifndef _DEMOREDBALL_H_
+#define _DEMOREDBALL_H_
+
+#include <rtf/yarp/YarpTestCase.h>
+#include <yarp/os/Property.h>
+#include <yarp/os/RateThread.h>
+#include <yarp/dev/PolyDriver.h>
+
+/**
+* \ingroup icub-tests
+*
+* This test verifies the point-to-point cartesian movement.
+*
+* Accepts the following parameters:
+* | Parameter name | Type   | Units | Default Value | Required |  Description  | Notes |
+* |:--------------:|:------:|:-----:|:-------------:|:--------:|:-------------:|:-----:|
+* |     context    | string |   -   |  demoRedBall  |    No    |   context containing the demoRedBall conf file  |   -   |
+* |      from      | string |   -   |  config.ini   |    No    |   demoRedBall configuration file  |   -   |
+*/
+class DemoRedBallTest : public YarpTestCase
+{
+    yarp::dev::PolyDriver drvJointArmL;
+    yarp::dev::PolyDriver drvJointArmR;
+    yarp::dev::PolyDriver drvJointTorso;
+    yarp::dev::PolyDriver drvJointHead;
+    yarp::dev::PolyDriver drvCartArmL;
+    yarp::dev::PolyDriver drvCartArmR;
+    yarp::dev::PolyDriver drvGaze;
+
+    yarp::os::RateThread *redBallPos;
+
+public:
+    DemoRedBallTest();
+    virtual ~DemoRedBallTest();
+    virtual bool setup(yarp::os::Property& property);
+    virtual void tearDown();
+    virtual void run();
+};
+
+#endif

--- a/suits/demoRedBall-icubSim.xml
+++ b/suits/demoRedBall-icubSim.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suit name="Demo Red Ball Test Suite">
+    <description>Testing Red Ball Demo functionalities</description>
+    <environment>--robotname icubSim</environment>
+    <fixture param="--fixture icubsim-demoRedBall-fixture.xml"> yarpmanager </fixture>
+
+    <test type="dll" param="--context demoRedBall --from config.ini"> DemoRedBallTest </test>
+</suit>

--- a/suits/fixtures/icubsim-demoRedBall-fixture.xml
+++ b/suits/fixtures/icubsim-demoRedBall-fixture.xml
@@ -49,11 +49,12 @@
     </module>
     <module>
         <name>iCubGui</name>
-        <parameters>--xpos 1500 --ypos 50 --width 370</parameters> 
+        <parameters>--xpos 800 --ypos 80 --width 370</parameters>
         <node>localhost</node>
    </module>
    <module>
         <name>demoRedBall</name>
+        <parameters>--from config-test.ini</parameters>
         <node>localhost</node>
         <dependencies>
             <port timeout="20">/icubSim/cartesianController/left_arm/state:o</port>
@@ -93,4 +94,3 @@
        <protocol>tcp</protocol>
    </connection>
 </application>
-

--- a/suits/fixtures/icubsim-demoRedBall-fixture.xml
+++ b/suits/fixtures/icubsim-demoRedBall-fixture.xml
@@ -1,0 +1,96 @@
+<application>
+    <name>Demo Red Ball</name>
+    <description>A fixture to prepare components required to test Red Ball Demo</description>
+    <version>1.0</version>
+    <authors>
+        <author email="ugo.pattacini@iit.it">Ugo Pattacini</author>
+    </authors>
+    <module>
+        <name>iCub_SIM</name>
+        <parameters></parameters>
+        <node>localhost</node>
+        <ensure>
+            <wait>10</wait>
+        </ensure>
+    </module>
+    <module>
+        <name>yarprobotinterface</name>
+        <parameters>--context simCartesianControl --config no_legs.xml</parameters>
+        <node>localhost</node>
+        <dependencies>
+            <port timeout="20">/icubSim/left_arm/state:o</port>
+            <port timeout="20">/icubSim/right_arm/state:o</port>
+        </dependencies>
+    </module>
+    <module>
+        <name>iKinCartesianSolver</name>
+        <parameters>--context simCartesianControl --part right_arm</parameters>
+        <node>localhost</node>
+        <dependencies>
+            <port timeout="20">/icubSim/right_arm/state:o</port>
+        </dependencies>
+    </module>
+    <module>
+        <name>iKinCartesianSolver</name>
+        <parameters>--context simCartesianControl --part left_arm</parameters>
+        <node>localhost</node>
+        <dependencies>
+            <port timeout="20">/icubSim/left_arm/state:o</port>
+        </dependencies>
+    </module>
+    <module>
+        <name>iKinGazeCtrl</name>
+        <parameters>--from configSim.ini</parameters>
+        <node>localhost</node>
+        <dependencies>
+            <port timeout="20">/icubSim/head/state:o</port>
+            <port timeout="20">/icubSim/inertial</port>
+        </dependencies>
+    </module>
+    <module>
+        <name>iCubGui</name>
+        <parameters>--xpos 1500 --ypos 50 --width 370</parameters> 
+        <node>localhost</node>
+   </module>
+   <module>
+        <name>demoRedBall</name>
+        <node>localhost</node>
+        <dependencies>
+            <port timeout="20">/icubSim/cartesianController/left_arm/state:o</port>
+            <port timeout="20">/icubSim/cartesianController/right_arm/state:o</port>
+            <port timeout="20">/iKinGazeCtrl/rpc</port>
+        </dependencies>
+   </module>
+
+   <connection>
+       <from>/icubSim/inertial</from>
+       <to>/iCubGui/inertial:i</to>
+       <protocol>udp</protocol>
+   </connection>
+   <connection>
+       <from>/icubSim/head/state:o</from>
+       <to>/iCubGui/head:i</to>
+       <protocol>udp</protocol>
+   </connection>
+   <connection>
+       <from>/icubSim/torso/state:o</from>
+       <to>/iCubGui/torso:i</to>
+       <protocol>udp</protocol>
+   </connection>
+   <connection>
+       <from>/icubSim/left_arm/state:o</from>
+       <to>/iCubGui/left_arm:i</to>
+       <protocol>udp</protocol>
+   </connection>
+   <connection>
+       <from>/icubSim/right_arm/state:o</from>
+       <to>/iCubGui/right_arm:i</to>
+       <protocol>udp</protocol>
+   </connection>
+   <connection>
+       <from>/demoRedBall/gui:o</from>
+       <to>/iCubGui/objects</to>
+       <protocol>tcp</protocol>
+   </connection>
+</application>
+


### PR DESCRIPTION
I've implemented a specific test covering the so-called [**Red Ball Demo**](https://github.com/robotology/icub-basic-demos/tree/master/demoRedBall) available from the [`icub-basic-demos`](https://github.com/robotology/icub-basic-demos) repository.

Do `git pull --rebase && make install` of `icub-basic-demos` before proceeding.

The test can be launched by calling:
```
$ testrunner --verbose --suit suits\demoRedBall-icubSim.xml
```
and it will check whether a couple of ball positions are reached ad gazed at by the robot. Homing the upper-body is also verified.

To have a quick flavor of this new test, watch the video below (click on the image):

[![screeshot](https://cloud.githubusercontent.com/assets/3738070/20554950/8bbddd44-b15f-11e6-9fe5-d01b1cf3bf71.jpg)](https://youtu.be/ackQ5Bfk9jk)

cc @randaz81 @apaikan @traversaro @vtikha @barbalberto @valegagge @lornat75 @drdanz 

@apaikan I've had the opportunity to work a bit with [**RTF**](https://github.com/robotology/robot-testing) these days, and it's a very great tool 😄 

