### PR TITLE
Fix installation documentation for macOS

### DIFF
--- a/doxygen/installation.dox
+++ b/doxygen/installation.dox
@@ -35,7 +35,7 @@ Note: in case CMake fails to detect the RTF package check that you installed RTF
 We need to add the plug-ins path to the OS-specific dynamic linker environment variable
 
 \li \b Linux `LD_LIBRARY_PATH`
-\li \b macOS `DYLD_FALLBACK_LIBRARY_PATH`
+\li \b macOS `DYLD_LIBRARY_PATH`
 \li \b Windows `PATH`
 
 As an example, under Linux:


### PR DESCRIPTION
Replaced DYLD_FALLBACK_LIBRARY_PATH environmental variable with DYLD_LIBRARY_PATH.

Setting DYLD_FALLBACK_LIBRARY_PATH to **any new path** overwrite the default value which may be vital for some application to work properly.
The DYLD_FALLBACK_LIBRARY_PATH default paths cannot be copied or appended.