### PR TITLE
Change order of YARP components in find_package call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ project(iCub-Tests)
 # find a version of RTF higher then 1.3.2
 # and with yarp support enabled
 find_package(RTF 1.3.3 COMPONENTS DLL REQUIRED)
-find_package(YARP 3.0 COMPONENTS rtf manager math REQUIRED)
+find_package(YARP 3.0 COMPONENTS math manager rtf REQUIRED)
 
 # set the output plugin directory to collect all the shared libraries
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins)


### PR DESCRIPTION
The new order follows the internal dependencies of YARP, so it is a bit more ordered, and additionally it is also a workaround for https://github.com/robotology/yarp/issues/1989 .