### PR TITLE
Modifications in .ini files of encoder tests

### DIFF
--- a/suites/contexts/icub/motorEncoderConsistency_left_arm.ini
+++ b/suites/contexts/icub/motorEncoderConsistency_left_arm.ini
@@ -4,7 +4,7 @@ part      left_arm
 joints    (0 1 2 3)
 home      (-30 30 10 45)
 speed     (20 20 20 20)
-max       (-20 40 20 55)
+max       (-20 50 20 55)
 min       (-40 20 0  35)
 cycles    10
 tolerance 1.0

--- a/suites/contexts/icub/motorEncoderConsistency_right_arm.ini
+++ b/suites/contexts/icub/motorEncoderConsistency_right_arm.ini
@@ -4,10 +4,10 @@ name      motorEncConsistency_rightArm
 joints    (0 1 2 3)
 home      (-30 30 10 45)
 speed     (20 20 20 20)
-max       (-20 40 20 55)
+max       (-20 50 20 55)
 min       (-40 20 0  35)
 cycles    10
-tolerance 1.0 
+tolerance 1.0
 matrix_size 4
 matrix   (               1                         0                         0                         0 \
                     -1.625                     1.625                         0                         0 \

--- a/suites/contexts/icub/optical_encoders_drift_torso.ini
+++ b/suites/contexts/icub/optical_encoders_drift_torso.ini
@@ -3,8 +3,8 @@ part      torso
 joints    (0 1 2)
 home      (0 0 0)
 speed     (20 20 20)
-max       (10  10  10)
-min       (-10 -10 -10)
-cycles    50
-tolerance 1.2
+max       (10  0  10)
+min       (-10 0 -10)
+cycles    1000
+tolerance 1.00
 plot_enabled 0


### PR DESCRIPTION
1) Modified the arm range of movement in the encoder Consistency test -wider movement so better test performance and plot visualization
2) In torso optical encoder drift test: tolerance 1.0 and 1000 cycles + modified range movements