### PR TITLE
Upgrade the Red Ball Demo Test to the use of Gazebo simulator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins)
 set(CMAKE_SHARED_MODULE_PREFIX "")
 
 # options
-option(ICUB_TESTS_USES_ICUB_MAIN "Turn on to compile the tests that depend on the icub-main repository" OFF)
+option(ICUB_TESTS_USES_ICUB_MAIN "Turn on to compile the tests that depend on the icub-main repository" ON)
 option(ICUB_TESTS_USES_CODYCO    "Turn on to compile the test that depend on the codyco-superbuil repository" OFF)
 
 # Build examples?
@@ -58,9 +58,6 @@ add_subdirectory(src/cartesian-control)
 # Build gaze controller tests
 add_subdirectory(src/gaze-control)
 
-# Build demoRedBall test
-add_subdirectory(src/demoRedBall)
-
 if(ICUB_TESTS_USES_CODYCO)
     add_subdirectory(src/torqueControl-gravityConsistency)
 endif()
@@ -72,7 +69,9 @@ add_subdirectory(src/motorEncodersSignCheck)
 
 # Build model consistency check
 if(ICUB_TESTS_USES_ICUB_MAIN)
+    find_package(ICUB REQUIRED)
     add_subdirectory(src/models-consistency)
+    add_subdirectory(src/demoRedBall)
 endif()
 
 # Build motor tests

--- a/src/demoRedBall/CMakeLists.txt
+++ b/src/demoRedBall/CMakeLists.txt
@@ -36,7 +36,8 @@ target_link_libraries(${PROJECT_NAME} RobotTestingFramework::RTF
                                       YARP::YARP_os
                                       YARP::YARP_init
                                       YARP::YARP_math
-                                      YARP::YARP_robottestingframework)
+                                      YARP::YARP_robottestingframework
+                                      ICUB::ctrlLib)
 
 # set the installation options
 install(TARGETS ${PROJECT_NAME}

--- a/src/demoRedBall/DemoRedBallTest.h
+++ b/src/demoRedBall/DemoRedBallTest.h
@@ -23,8 +23,10 @@
 
 #include <string>
 #include <yarp/robottestingframework/TestCase.h>
+#include <yarp/os/Bottle.h>
 #include <yarp/os/Property.h>
-#include <yarp/os/PeriodicThread.h>
+#include <yarp/os/RpcClient.h>
+#include <yarp/os/BufferedPort.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/IEncoders.h>
 #include <yarp/dev/CartesianControl.h>
@@ -70,8 +72,10 @@ class DemoRedBallTest : public yarp::robottestingframework::TestCase
     yarp::dev::IEncoders         *ienc;
     } arm_under_test;
 
-    yarp::os::PeriodicThread *redBallPos;
+    yarp::os::RpcClient rpcPort;
+    yarp::os::BufferedPort<yarp::os::Bottle> guiPort;
     void testBallPosition(const yarp::sig::Vector &pos);
+    bool getBallPosition(const yarp::os::Bottle* b, yarp::sig::Vector& pos);
 
 public:
     DemoRedBallTest();

--- a/src/models-consistency/CMakeLists.txt
+++ b/src/models-consistency/CMakeLists.txt
@@ -23,16 +23,7 @@ endif()
 
 project(iKiniDynConsistencyTest)
 
-find_package(ICUB REQUIRED)
-
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ICUB_MODULE_PATH})
-
-include(iCubHelpers)
-
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${ICUB_LINK_FLAGS}")
-
-# add include directories
-include_directories(${ICUB_INCLUDE_DIRS})
 
 # import math symbols from standard cmath
 add_definitions(-D_USE_MATH_DEFINES)
@@ -47,8 +38,8 @@ target_link_libraries(${PROJECT_NAME} RobotTestingFramework::RTF
                                       YARP::YARP_init
                                       YARP::YARP_math
                                       YARP::YARP_robottestingframework
-                                      iKin
-                                      iDyn)
+                                      ICUB::iKin
+                                      ICUB::iDyn)
 
 # set the installation options
 install(TARGETS ${PROJECT_NAME}

--- a/suites/fixtures/icubsim-demoRedBall-fixture.xml
+++ b/suites/fixtures/icubsim-demoRedBall-fixture.xml
@@ -6,53 +6,66 @@
         <author email="ugo.pattacini@iit.it">Ugo Pattacini</author>
     </authors>
     <module>
-        <name>iCub_SIM</name>
+        <name>gzserver</name>
+        <parameters>-s libgazebo_yarp_clock.so grasp-ball-gazebo.sdf</parameters>
+        <node>localhost</node>
+    </module>
+    <module>
+        <name>gzclient</name>
         <parameters></parameters>
         <node>localhost</node>
-        <ensure>
-            <wait>10</wait>
-        </ensure>
     </module>
     <module>
         <name>yarprobotinterface</name>
-        <parameters>--context simCartesianControl --config no_legs.xml</parameters>
+        <parameters>--context gazeboCartesianControl --config no_legs.xml</parameters>
         <node>localhost</node>
         <dependencies>
+            <port timeout="20">/icubSim/torso/state:o</port>
             <port timeout="20">/icubSim/left_arm/state:o</port>
             <port timeout="20">/icubSim/right_arm/state:o</port>
         </dependencies>
+        <environment>YARP_CLOCK=/clock</environment>
+        <ensure>
+            <wait when="stop">5</wait>
+        </ensure>       
     </module>
     <module>
         <name>iKinCartesianSolver</name>
-        <parameters>--context simCartesianControl --part right_arm</parameters>
+        <parameters>--context gazeboCartesianControl --part right_arm</parameters>
         <node>localhost</node>
         <dependencies>
+            <port timeout="20">/icubSim/torso/state:o</port>
             <port timeout="20">/icubSim/right_arm/state:o</port>
         </dependencies>
+        <environment>YARP_CLOCK=/clock</environment>
     </module>
     <module>
         <name>iKinCartesianSolver</name>
-        <parameters>--context simCartesianControl --part left_arm</parameters>
+        <parameters>--context gazeboCartesianControl --part left_arm</parameters>
         <node>localhost</node>
         <dependencies>
+            <port timeout="20">/icubSim/torso/state:o</port>
             <port timeout="20">/icubSim/left_arm/state:o</port>
         </dependencies>
+        <environment>YARP_CLOCK=/clock</environment>
     </module>
     <module>
         <name>iKinGazeCtrl</name>
-        <parameters>--from configSim.ini</parameters>
+        <parameters>--context gazeboCartesianControl --from iKinGazeCtrl.ini</parameters>
         <node>localhost</node>
         <dependencies>
+            <port timeout="20">/icubSim/torso/state:o</port>
             <port timeout="20">/icubSim/head/state:o</port>
             <port timeout="20">/icubSim/inertial</port>
         </dependencies>
+        <environment>YARP_CLOCK=/clock</environment>
     </module>
     <module>
-        <name>iCubGui</name>
-        <parameters>--xpos 800 --ypos 80 --width 370</parameters>
+        <name>pf3dTracker</name>
+        <parameters>--from pf3dTracker-gazebo.ini</parameters>
         <node>localhost</node>
-   </module>
-   <module>
+    </module>
+    <module>
         <name>demoRedBall</name>
         <parameters>--from config-test.ini</parameters>
         <node>localhost</node>
@@ -61,36 +74,68 @@
             <port timeout="20">/icubSim/cartesianController/right_arm/state:o</port>
             <port timeout="20">/iKinGazeCtrl/rpc</port>
         </dependencies>
-   </module>
+    </module>
+    <module>
+        <name>yarpview</name>
+        <parameters>--name /PF3DTracker_viewer --x 320 --y 80 --p 50 --compact</parameters>
+        <node>localhost</node>
+        <dependencies>
+            <port timeout="20">/demoRedBall/rpc</port>
+        </dependencies>
+        <environment>YARP_CLOCK=/clock</environment>
+    </module>
+    <module>
+        <name>iCubGui</name>
+        <parameters>--xpos 1400 --ypos 80 --width 370</parameters>
+        <node>localhost</node>
+        <dependencies>
+            <port timeout="20">/demoRedBall/rpc</port>
+        </dependencies>
+    </module>
 
-   <connection>
-       <from>/icubSim/inertial</from>
-       <to>/iCubGui/inertials/measures:i</to>
-       <protocol>udp</protocol>
-   </connection>
-   <connection>
-       <from>/icubSim/head/state:o</from>
-       <to>/iCubGui/head:i</to>
-       <protocol>udp</protocol>
-   </connection>
-   <connection>
-       <from>/icubSim/torso/state:o</from>
-       <to>/iCubGui/torso:i</to>
-       <protocol>udp</protocol>
-   </connection>
-   <connection>
-       <from>/icubSim/left_arm/state:o</from>
-       <to>/iCubGui/left_arm:i</to>
-       <protocol>udp</protocol>
-   </connection>
-   <connection>
-       <from>/icubSim/right_arm/state:o</from>
-       <to>/iCubGui/right_arm:i</to>
-       <protocol>udp</protocol>
-   </connection>
-   <connection>
-       <from>/demoRedBall/gui:o</from>
-       <to>/iCubGui/objects</to>
-       <protocol>tcp</protocol>
-   </connection>
+    <connection>
+        <from>/icubSim/inertial</from>
+        <to>/iCubGui/inertials/measures:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/icubSim/head/state:o</from>
+        <to>/iCubGui/head:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/icubSim/torso/state:o</from>
+        <to>/iCubGui/torso:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/icubSim/left_arm/state:o</from>
+        <to>/iCubGui/left_arm:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/icubSim/right_arm/state:o</from>
+        <to>/iCubGui/right_arm:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/demoRedBall/gui:o</from>
+        <to>/iCubGui/objects</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+    <connection>
+        <from>/icubSim/cam/left/rgbImage:o</from>
+        <to>/pf3dTracker/video:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+    <connection>
+        <from>/pf3dTracker/video:o</from>
+        <to>/PF3DTracker_viewer</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+    <connection>
+        <from>/pf3dTracker/data:o</from>
+        <to>/demoRedBall/trackTarget:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
 </application>


### PR DESCRIPTION
Leveraging the nice addition made in https://github.com/robotology/icub-basic-demos/pull/32 and depending on https://github.com/robotology/icub-basic-demos/pull/34, this PR upgrades the Red Ball Demo Test in order to make use of Gazebo in place of iCub_SIM.

Other notes:
- `ICUB_TESTS_USES_ICUB_MAIN` is now ON by default.
- The test itself now depends on `ICUB::ctrlLib` for the median filtering.

The proposed changes have been successfully tested ✔️ 
Despite this, let me keep the PR in draft as I'd like to merge it only once @mfussi66 will have finalized his work with the current test configuration.

More to come later.