### PR TITLE
Fix plot_enabled parameter check

### DIFF
--- a/src/opticalEncoders-drift/opticalEncodersDrift.cpp
+++ b/src/opticalEncoders-drift/opticalEncodersDrift.cpp
@@ -99,10 +99,7 @@ bool OpticalEncodersDrift::setup(yarp::os::Property& property) {
     cycles = property.find("cycles").asInt32();
     ROBOTTESTINGFRAMEWORK_ASSERT_ERROR_IF_FALSE(cycles>=0,"invalid cycles");
 
-    if(property.check("plot_enabled"))
-        plot = property.find("plot").asBool();
-    else
-        plot = true;
+    plot = property.find("plot_enabled").asBool();
 
     if(plot)
         ROBOTTESTINGFRAMEWORK_TEST_REPORT("This test will run gnuplot utility at the end.");


### PR DESCRIPTION
As per the title, this PR contains a fix for correct plot generation following test execution.

The parameter we should check inside the `.ini` [file](https://github.com/robotology/icub-tests/blob/4f72f12d3b342d41b3f46d8c9e3d02eac08dcd23/suites/contexts/icub/optical_encoders_drift_left_arm.ini#L10) is `plot_enabled`, and not the [plot variable](https://github.com/robotology/icub-tests/blob/4f72f12d3b342d41b3f46d8c9e3d02eac08dcd23/src/opticalEncoders-drift/opticalEncodersDrift.cpp#L103).

The idea is to follow this logic:

- if `plot_enabled` is not in the conf at all => `plot = false`

- if `plot_enabled` is in the conf => `plot = value of plot enabled`

We tested with the setup and it follows the expected behavior.

cc @vvasco @valegagge 
