### PR TITLE
OpticalEncodersDrift: Added features regarding folder architecture and date/time for saved files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@
 
 
 cmake_minimum_required(VERSION 3.5)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(iCub-Tests)
 

--- a/src/opticalEncoders-drift/opticalEncodersDrift.cpp
+++ b/src/opticalEncoders-drift/opticalEncodersDrift.cpp
@@ -217,7 +217,7 @@ bool OpticalEncodersDrift::goHome()
     return true;
 }
 
-bool OpticalEncodersDrift::saveToFile(std::string filename, yarp::os::Bottle &b)
+bool OpticalEncodersDrift::saveToFile(const std::string &filename, const yarp::os::Bottle &b)
 {
     std::fstream fs;
     fs.open (filename.c_str(), std::fstream::out);

--- a/src/opticalEncoders-drift/opticalEncodersDrift.h
+++ b/src/opticalEncoders-drift/opticalEncodersDrift.h
@@ -72,7 +72,7 @@ public:
 
     bool goHome();
     void setMode(int desired_mode);
-    bool saveToFile(std::string filename, yarp::os::Bottle &b);
+    bool saveToFile(const std::string &filename, const yarp::os::Bottle &b);
 
 private:
     std::string robotName;

--- a/src/opticalEncoders-drift/opticalEncodersDrift.h
+++ b/src/opticalEncoders-drift/opticalEncodersDrift.h
@@ -72,7 +72,7 @@ public:
 
     bool goHome();
     void setMode(int desired_mode);
-    void saveToFile(std::string filename, yarp::os::Bottle &b);
+    bool saveToFile(std::string filename, yarp::os::Bottle &b);
 
 private:
     std::string robotName;


### PR DESCRIPTION
This PR includes improvements and additions that make saving files more organized and intuitive. With the following code, a nested tree structure is created, which is useful for automating the optical encoders drift test without overwriting files (as was the case before). 

Example:

```
results
├── iCubErzelli02
│   └── encoders-icub_30052022
│       └── encDrift
│           ├── encDrift_plot_left_arm_30052022_1612.txt
│           ├── encDrift_plot_right_arm_30052022_1600.txt
│           └── encDrift_plot_right_arm_30052022_1614.txt
└── RobotName
    └── encoders-icub_30052022
        └── encDrift
            ├── encDrift_plot_left_arm_30052022_1617.txt
            └── encDrift_plot_right_arm_30052022_1619.txt
```

For greater accuracy related to reporting, date and time of test execution and file generation have been included, and for folder names the value is read directly from the environment variables (`$YARP_ROBOT_NAME`).