### PR TITLE
IMU Test - Fix logic of "no_legs" parameter 

### DIFF
--- a/src/imu/imu.cpp
+++ b/src/imu/imu.cpp
@@ -308,9 +308,10 @@ void Imu::setupBrokers()
     for (auto part : partsList)
     {
         if(part.find("leg") != std::string::npos)
-        {
+            strParam = "";
+
+        else
             strParam = "no_legs";
-        }
     }
 
     strCmd.clear();


### PR DESCRIPTION
With https://github.com/robotology/icub-tests/pull/72, we added the possibility to parse the `remoteControlBoards` list within the `test_imu.ini` file to search for the legs. Unfortunately, I found an error in the logic implementing this functionality since:

```cpp
  for (auto part : partsList)
  {
      if(part.find("leg") != std::string::npos)
      {
          strParam = "no_legs";
      }
  }
```

searches if the substring `leg` *is found* and, if yes, it passes to the move.sh the parameter `no_legs`. This is the opposite of expected behavior. 

This PR should fix this error

cc @pattacini 