### PR TITLE
Drop deprecated mambaforge installer and use conda instead of mamba

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,11 @@ jobs:
     steps:
     - uses: actions/checkout@main
 
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-variant: Mambaforge
         miniforge-version: latest
         channels: conda-forge,robotology
         channel-priority: true
-
 
     - name: Dependencies
       shell: bash -l {0}
@@ -40,9 +38,9 @@ jobs:
         # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
         conda config --remove channels defaults
         # Compilation related dependencies
-        mamba install cmake compilers make ninja pkg-config
+        conda install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install ycm-cmake-modules yarp opencv idyntree robot-testing-framework icub-main robometry
+        conda install ycm-cmake-modules yarp opencv idyntree robot-testing-framework icub-main robometry
 
     - name: Configure [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
The `mambaforge` installer is now deprecated and is failing more and more frequently, and will stop working in 2025 (see https://github.com/conda-forge/miniforge?tab=readme-ov-file#should-i-choose-one-or-another-going-forward-at-the-risk-of-one-of-them-getting-deprecated), so we switch to just use `miniforge` .

On the other hand, `conda` is now as fast as `mamba` (see https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community), so to simplify the CI script we can always use conda instead of alternating conda and mamba.