### PR TITLE
Update CI workflow to use Windows 2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, windows-2019, macos-latest]
+        os: [ubuntu-latest, windows-2022, macos-latest]
 
     steps:
     - uses: actions/checkout@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ on:
   pull_request:
   schedule:
   # * is a special character in YAML so you have to quote this string
-  # Execute a "nightly" build at 2 AM UTC 
+  # Execute a "nightly" build at 2 AM UTC
   - cron:  '0 2 * * *'
   workflow_dispatch:
-    
+
 jobs:
   build:
     name: '[${{ matrix.os }}@${{ matrix.build_type }}]'
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, windows-2022, macos-latest]
+        os: [ubuntu-latest, windows-2022]
 
     steps:
     - uses: actions/checkout@main
@@ -35,8 +35,6 @@ jobs:
     - name: Dependencies
       shell: bash -l {0}
       run: |
-        # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
-        conda config --remove channels defaults
         # Compilation related dependencies
         conda install cmake compilers make ninja pkg-config
         # Actual dependencies
@@ -59,7 +57,7 @@ jobs:
         cd build
         cmake -G"Visual Studio 16 2019" -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DICUB_TESTS_COMPILES_IMU_TEST=ON ..
-      
+
     - name: Build
       shell: bash -l {0}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -G"Visual Studio 16 2019" -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install \
+        cmake -G"Visual Studio 17 2022" -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DICUB_TESTS_COMPILES_IMU_TEST=ON ..
 
     - name: Build


### PR DESCRIPTION
This is because in June 2025 the windows-2019 runners have been deprecated, they will start soon to be dismissed